### PR TITLE
fix: update broken Mage documentation links

### DIFF
--- a/Tools/Workflow Orchestrators/Mage.md
+++ b/Tools/Workflow Orchestrators/Mage.md
@@ -142,9 +142,9 @@ These outputs can be previewed and analyzed via Mage's GUI. This reduces frictio
 | 🎶  | [Orchestration](https://docs.mage.ai/design/data-pipeline-management)                | Schedule and manage data pipelines with observability.                 |
 | --- | ---------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | 📓  | [Notebook](https://docs.mage.ai/about/features#notebook-for-building-data-pipelines) | Interactive Python, SQL, & R editor for coding data pipelines.         |
-| 🏗️  | [Data integrations](https://docs.mage.ai/integrations/data-integrations)             | Synchronize data from 3rd party sources to your internal destinations. |
-| 🚰  | [Streaming pipelines](https://docs.mage.ai/guides/streaming-pipeline)                | Ingest and transform real-time data.                                   |
-| ❎  | [DBT](https://docs.mage.ai/dbt/overview)                                             | Build, run, and manage your dbt models with Mage.                      |
+| 🏗️  | [Data integrations](https://docs.mage.ai/data-integrations/overview)             | Synchronize data from 3rd party sources to your internal destinations. |
+| 🚰  | [Streaming pipelines](https://docs.mage.ai/guides/streaming/tutorials/streaming-pipeline)                | Ingest and transform real-time data.                                   |
+| ❎  | [DBT](https://docs.mage.ai/guides/dbt/overview)                                             | Build, run, and manage your dbt models with Mage.                      |
 
 ## 🏔️ [Core design principles](https://docs.mage.ai/design/core-design-principles)
 


### PR DESCRIPTION
## Summary

Fixes 3 broken links in the Mage page that were flagged by the automated link checker.

## Changes

`Tools/Workflow Orchestrators/Mage.md`: Updated three `docs.mage.ai` URLs that returned 404 after the Mage docs site restructured its paths:

| Old URL | New URL | Status |
|---------|---------|--------|
| `/dbt/overview` | `/guides/dbt/overview` | 200 |
| `/integrations/data-integrations` | `/data-integrations/overview` | 200 |
| `/guides/streaming-pipeline` | `/guides/streaming/tutorials/streaming-pipeline` | 200 |

New URLs verified via `curl` and cross-referenced against the Mage docs index.

Fixes #141

This contribution was developed with AI assistance (Claude Code).