### PR TITLE
fix(linkcheck): allowlist montecarlodata.com (refs #144)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,2 @@
 http://docs.basho.com/riak/kv/
+https://www.montecarlodata.com/


### PR DESCRIPTION
Refs #144.

## What this fixes

The link checker on `main` reports `https://www.montecarlodata.com/` (linked from `Tools/Data Quality/Monte Carlo.md`) as a 415 "Unsupported Media Type" error. The URL itself is fine: a normal browser request returns 200, and the page is the canonical Monte Carlo Data home page. The 415 is `lychee-action`'s HEAD request being rejected by the upstream server (likely a User-Agent or Accept-header filter), not a real broken link.

## What I changed

Added `https://www.montecarlodata.com/` to `.lycheeignore`. That file already silences one similar false-positive (`http://docs.basho.com/riak/kv/`), so this matches the existing convention in the repo.

## What I did NOT change

The Matillion entry in #144 is being handled by the in-flight PR #145, so I kept this PR scoped to the Monte Carlo entry only. After both land, #144's two reported errors should both be cleared.

## Verification

- `curl -A "Mozilla/5.0" https://www.montecarlodata.com/` returns 200 (URL is genuinely valid).
- The accept list in `.github/workflows/check_links.yml` includes 200, 401, 403, 406, 429, 999, but not 415, so a 415 from this URL will still fail the next scheduled run unless it is allowlisted.

## Self-promotion check

Per the contributing guide ("Limit self-promotion"): the link is not promotional. It is the existing source-of-truth URL for the Monte Carlo Data tool already documented on the page. No new outbound link is added.